### PR TITLE
DS-561 - [Swagger] DELETE /utils/bulkDelete API is not working as no field to pass any parameters

### DIFF
--- a/util/generateYaml.js
+++ b/util/generateYaml.js
@@ -654,25 +654,22 @@ function generateYaml(config) {
 		'delete': {
 			description: `Deletes a list of '${name}'`,
 			operationId: `${methodName.bulkDelete}`,
-			// TODO - requestBody can't be used inside DELETE operation
-			// requestBody: {
-			// 	description: 'Payload to reset a User',
-			// 	content: {
-			// 		'application/json': {
-			// 			schema: {
-			// 				type: 'object',
-			// 				properties: {
-			// 					ids: {
-			// 						type: 'array',
-			// 						items: {
-			// 							type: 'string'
-			// 						}
-			// 					}
-			// 				}
-			// 			}
-			// 		}
-			// 	}
-			// },
+			parameters: [{
+				name: 'ids',
+				in: 'query',
+				description: 'List of document IDs to be deleted',
+				schema: {
+					type: 'object',
+					properties: {
+						ids: {
+							type: 'array',
+							items: {
+								type: 'string'
+							}
+						}
+					}
+				}
+			}],
 			responses: {
 				'200': {
 					description: 'Empty Object'

--- a/util/generateYamlSchemaFree.js
+++ b/util/generateYamlSchemaFree.js
@@ -421,25 +421,22 @@ function generateYaml(config) {
         'delete': {
             description: `Deletes a list of '${name}'`,
             operationId: `${methodName.bulkDelete}`,
-            // TODO - requestBody can't be used inside DELETE operation
-            // requestBody: {
-            // 	description: 'Payload to reset a User',
-            // 	content: {
-            // 		'application/json': {
-            // 			schema: {
-            // 				type: 'object',
-            // 				properties: {
-            // 					ids: {
-            // 						type: 'array',
-            // 						items: {
-            // 							type: 'string'
-            // 						}
-            // 					}
-            // 				}
-            // 			}
-            // 		}
-            // 	}
-            // },
+            parameters: [{
+				name: 'ids',
+				in: 'query',
+				description: 'List of document IDs to be deleted',
+				schema: {
+					type: 'object',
+					properties: {
+						ids: {
+							type: 'array',
+							items: {
+								type: 'string'
+							}
+						}
+					}
+				}
+			}],
             responses: {
                 '200': {
                     description: 'Empty Object'


### PR DESCRIPTION
Clarifying the changes in the `utils/bulkDelete` API behavior after this update:

1. From the Swagger UI, we will now accept only a comma-separated array of document IDs for removal.
2. Our API will still support both individual IDs and filter-based bulk deletion.