### PR TITLE
Add bulkUpdate and bulkUpsert in API docs

### DIFF
--- a/api/controllers/swaggerDoc.controller.js
+++ b/api/controllers/swaggerDoc.controller.js
@@ -5,7 +5,7 @@ const { generateYamlSchemaFree } = require('../../util/generateYamlSchemaFree');
 const logger = global.logger;
 const mongoose = require('mongoose');
 const jsyaml = require('js-yaml');
-const apiNotAllowed = ['/file/upload', '/file/{id}/view', '/file/{id}/remove', '/fileMapper/mapping', '/fileMapper/create', '/hook', '/lock', '/utils/experienceHook', '/fileMapper/enrich', '/health/live', '/health/ready', '/fileMapper/{fileId}/create', '/fileMapper/{fileId}/mapping', '/fileMapper/{fileId}/count', '/fileMapper/{fileId}', '/fileMapper/{fileId}/enrichDataForWF', '/utils/fileTransfers/{id}', '/utils/fileTransfers/count', '/utils/fileTransfers', '/utils/hrefUpdate', '/utils/securedFields', '/utils/fileTransfers/{fileId}/readStatus'];
+const apiNotAllowed = ['/file/upload', '/file/{id}/view', '/file/{id}/remove', '/fileMapper/mapping', '/fileMapper/create', '/hook', '/lock', '/utils/experienceHook', '/fileMapper/enrich', '/health/live', '/health/ready', '/fileMapper/{fileId}/create', '/fileMapper/{fileId}/mapping', '/fileMapper/{fileId}/count', '/fileMapper/{fileId}', '/fileMapper/{fileId}/enrichDataForWF', '/utils/fileTransfers/{id}', '/utils/fileTransfers/count', '/utils/fileTransfers', '/utils/hrefUpdate', '/utils/securedFields', '/utils/fileTransfers/{fileId}/readStatus', '/utils/bulkShow'];
 const definitionNotAllowed = ['mapping', 'bulkCreateData'];
 function addAuthHeader(paths, jwt) {
 	Object.keys(paths).forEach(path => {

--- a/util/generateYaml.js
+++ b/util/generateYaml.js
@@ -265,6 +265,8 @@ function getMethodNames(config) {
 	obj.bulkShow = `v1_${name}BulkShow`;
 	obj.securedFields = `v1_${name}SecuredFields`;
 	obj.bulkDelete = `v1_${name}BulkDelete`;
+	obj.bulkUpdate = `v1_${name}BulkUpdate`;
+    obj.bulkUpsert = `v1_${name}BulkUpsert`;
 	obj.fileUpload = `v1_${name}FileUpload`;
 	obj.fileView = `v1_${name}FileView`;
 	obj.fileDownload = `v1_${name}FileDownload`;
@@ -717,6 +719,125 @@ function generateYaml(config) {
 		}
 	};
 
+    swagger.paths['/utils/bulkUpdate'] = {
+        'x-swagger-router-controller': `${methodName.controller}`,
+        'put': {
+            description: `Bulk update an existing list of '${name}' documents.`,
+            operationId: `${methodName.bulkUpdate}`,
+            parameters: [
+                {
+                    name: 'ids',
+                    in: 'query',
+                    description: 'Array of document IDs to be updated.',
+                    schema: { 
+                        type: 'object', 
+                        properties: 
+                        { 
+                            ids: 
+                            { 
+                                type: 'array', 
+                                items: { type: 'string' } 
+                            } 
+                        } 
+                    }
+                }
+            ],
+            requestBody: {
+                description: `Payload to update '${name}' documents.`,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object'
+                        }
+                    }
+                }
+            },
+            responses: {
+                '200': {
+                    description: 'Success. Returns a list of updated entities.'
+                },
+                '400': {
+                    description: 'Bad request. The request parameters are invalid or incomplete.'
+                },
+                '403': {
+                    description: 'Forbidden. You do not have permission to update records.'
+                },
+                '500': {
+                    description: 'Internal server error. An unexpected error occurred during processing.'
+                }
+            },
+            security: [
+                {
+                    "bearerAuth": []
+                }
+            ]
+        }
+    };
+    
+    swagger.paths['/utils/bulkUpsert'] = {
+        'x-swagger-router-controller': `${methodName.controller}`,
+        'post': {
+            description: `Bulk upsert a list of '${name}' documents.`,
+            operationId: `${methodName.bulkUpsert}`,
+            parameters: [
+                {
+                    name: 'update',
+                    in: 'query',
+                    description: 'Flag indicating whether to update existing documents (true or false).',
+                    schema: { type: 'boolean' }
+                },
+                {
+                    name: 'insert',
+                    in: 'query',
+                    description: 'Flag indicating whether to insert new documents (true or false).',
+                    schema: { type: 'boolean' }
+                }
+            ],
+            requestBody: {
+                description: `Payload to update/insert '${name}' documents.`,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                keys: {
+                                    type: 'array',
+                                    items: { type: 'string' },
+                                    description: 'Array of document keys to identify the documents to update/insert.'
+                                },
+                                docs: {
+                                    type: 'array',
+                                    items: { type: 'object' },
+                                    description: 'Array of documents to be updated/inserted.'
+                                }
+                            },
+                            required: ['keys', 'docs']
+                        }
+                    }
+                }
+            },
+            responses: {
+                '200': {
+                    description: 'Success. Returns a list of updated or inserted entities.'
+                },
+                '400': {
+                    description: 'Bad request. The request parameters are invalid or incomplete.'
+                },
+                '403': {
+                    description: 'Forbidden. The user does not have permission for this operation.'
+                },
+                '500': {
+                    description: 'Internal server error. An unexpected error occurred during processing.'
+                }
+            },
+            security: [
+                {
+                    "bearerAuth": []
+                }
+            ]
+        }
+    };
+    
 	swagger.paths['/utils/count'] = {
 		'x-swagger-router-controller': `${methodName.controller}`,
 		'get': {

--- a/util/generateYamlSchemaFree.js
+++ b/util/generateYamlSchemaFree.js
@@ -124,6 +124,8 @@ function getMethodNames(config) {
     obj.bulkShow = `v1_${name}BulkShow`;
     //obj.securedFields = `v1_${name}SecuredFields`;
     obj.bulkDelete = `v1_${name}BulkDelete`;
+    obj.bulkUpdate = `v1_${name}BulkUpdate`;
+    obj.bulkUpsert = `v1_${name}BulkUpsert`;
     obj.fileUpload = `v1_${name}FileUpload`;
     obj.fileView = `v1_${name}FileView`;
     obj.fileDownload = `v1_${name}FileDownload`;
@@ -484,6 +486,125 @@ function generateYaml(config) {
         }
     };
 
+    swagger.paths['/utils/bulkUpdate'] = {
+        'x-swagger-router-controller': `${methodName.controller}`,
+        'put': {
+            description: `Bulk update an existing list of '${name}' documents.`,
+            operationId: `${methodName.bulkUpdate}`,
+            parameters: [
+                {
+                    name: 'ids',
+                    in: 'query',
+                    description: 'Array of document IDs to be updated.',
+                    schema: { 
+                        type: 'object', 
+                        properties: 
+                        { 
+                            ids: 
+                            { 
+                                type: 'array', 
+                                items: { type: 'string' } 
+                            } 
+                        } 
+                    }
+                }
+            ],
+            requestBody: {
+                description: `Payload to update '${name}' documents.`,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object'
+                        }
+                    }
+                }
+            },
+            responses: {
+                '200': {
+                    description: 'Success. Returns a list of updated entities.'
+                },
+                '400': {
+                    description: 'Bad request. The request parameters are invalid or incomplete.'
+                },
+                '403': {
+                    description: 'Forbidden. You do not have permission to update records.'
+                },
+                '500': {
+                    description: 'Internal server error. An unexpected error occurred during processing.'
+                }
+            },
+            security: [
+                {
+                    "bearerAuth": []
+                }
+            ]
+        }
+    };
+    
+    swagger.paths['/utils/bulkUpsert'] = {
+        'x-swagger-router-controller': `${methodName.controller}`,
+        'post': {
+            description: `Bulk upsert a list of '${name}' documents.`,
+            operationId: `${methodName.bulkUpsert}`,
+            parameters: [
+                {
+                    name: 'update',
+                    in: 'query',
+                    description: 'Flag indicating whether to update existing documents (true or false).',
+                    schema: { type: 'boolean' }
+                },
+                {
+                    name: 'insert',
+                    in: 'query',
+                    description: 'Flag indicating whether to insert new documents (true or false).',
+                    schema: { type: 'boolean' }
+                }
+            ],
+            requestBody: {
+                description: `Payload to update/insert '${name}' documents.`,
+                content: {
+                    'application/json': {
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                keys: {
+                                    type: 'array',
+                                    items: { type: 'string' },
+                                    description: 'Array of document keys to identify the documents to update/insert.'
+                                },
+                                docs: {
+                                    type: 'array',
+                                    items: { type: 'object' },
+                                    description: 'Array of documents to be updated/inserted.'
+                                }
+                            },
+                            required: ['keys', 'docs']
+                        }
+                    }
+                }
+            },
+            responses: {
+                '200': {
+                    description: 'Success. Returns a list of updated or inserted entities.'
+                },
+                '400': {
+                    description: 'Bad request. The request parameters are invalid or incomplete.'
+                },
+                '403': {
+                    description: 'Forbidden. The user does not have permission for this operation.'
+                },
+                '500': {
+                    description: 'Internal server error. An unexpected error occurred during processing.'
+                }
+            },
+            security: [
+                {
+                    "bearerAuth": []
+                }
+            ]
+        }
+    };
+    
     swagger.paths['/utils/count'] = {
         'x-swagger-router-controller': `${methodName.controller}`,
         'get': {


### PR DESCRIPTION
This commit 

1. Adds two new APIs: `/utils/bulkUpdate`, `/utils/bulkUpsert`
2. Removes the redundant `/utils/bulkShow` API