### PR TITLE
Introduce direct reference for data.stack-utils in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "author": "Jugnu Agrawal <jugnu@appveen.com>",
     "license": "ISC",
     "dependencies": {
-        "@appveen/data.stack-utils": "https://github.com/appveen/data.stack-utils",
+        "@appveen/data.stack-utils": "github:appveen/data.stack-utils",
         "@appveen/ds-auth-cache": "^1.0.8",
         "@appveen/json-utils": "^1.1.0",
         "@appveen/swagger-mongoose-crud": "^2.0.1",


### PR DESCRIPTION
As of now, we are introducing a direct reference to the main branch of the `data.stack-utils` repository. This change is necessary to incorporate and test new features in `data.stack-utils`. After thorough testing, we will release the latest changes and update the `package.json` with the appropriate release reference.