### PR TITLE
DS-561 - [Swagger] DELETE /utils/bulkDelete API is not working as no field to pass any parameters

### DIFF
--- a/util/generateYaml.js
+++ b/util/generateYaml.js
@@ -659,17 +659,9 @@ function generateYaml(config) {
 			parameters: [{
 				name: 'ids',
 				in: 'query',
-				description: 'List of document IDs to be deleted',
+				description: 'Comma-separated list of document IDs to be deleted',
 				schema: {
-					type: 'object',
-					properties: {
-						ids: {
-							type: 'array',
-							items: {
-								type: 'string'
-							}
-						}
-					}
+					type: 'string',  
 				}
 			}],
 			responses: {

--- a/util/generateYamlSchemaFree.js
+++ b/util/generateYamlSchemaFree.js
@@ -426,17 +426,9 @@ function generateYaml(config) {
 			parameters: [{
 				name: 'ids',
 				in: 'query',
-				description: 'List of document IDs to be deleted',
+				description: 'Comma-separated list of document IDs to be deleted',
 				schema: {
-					type: 'object',
-					properties: {
-						ids: {
-							type: 'array',
-							items: {
-								type: 'string'
-							}
-						}
-					}
+					type: 'string',  
 				}
 			}],
 			responses: {


### PR DESCRIPTION
`DELETE /utils/bulkDelete` API now supports comma based string ids as parameters on swagger UI

![image](https://github.com/datanimbus/dnio-service-manager/assets/58633735/a9aa63cf-2dbc-4de8-8117-e31bbb69977d)
