### PR TITLE
Add 'file' parameter to /utils/file/upload endpoint Swagger doc

### DIFF
--- a/util/generateYaml.js
+++ b/util/generateYaml.js
@@ -1002,7 +1002,15 @@ function generateYaml(config) {
 		'post': {
 			description: 'Uploads the file',
 			operationId: `${methodName.fileUpload}`,
+			consumes: ['multipart/form-data'],
 			parameters: [
+				{
+					name: 'file',
+					in: 'formData',
+					required: true,
+					type: 'file',  
+					description: 'The file to upload',
+				},
 				{
 					name: 'encryptionKey',
 					in: 'query',

--- a/util/generateYamlSchemaFree.js
+++ b/util/generateYamlSchemaFree.js
@@ -766,10 +766,18 @@ function generateYaml(config) {
 
 	swagger.paths['/utils/file/upload'] = {
 		'x-swagger-router-controller': `${methodName.controller}`,
+		consumes: ['multipart/form-data'],
 		'post': {
 			description: 'Uploads the file',
 			operationId: `${methodName.fileUpload}`,
 			parameters: [
+				{
+					name: 'file',
+					in: 'formData',
+					required: true,
+					type: 'file',  
+					description: 'The file to upload',
+				},
 				{
 					name: 'encryptionKey',
 					in: 'query',


### PR DESCRIPTION
Added 'file' parameter to the Swagger documentation for the /utils/file/upload endpoint.