### PR TITLE
[swagger] Expected request body for /{id}/math is an array

### DIFF
--- a/util/generateYaml.js
+++ b/util/generateYaml.js
@@ -577,7 +577,11 @@ function generateYaml(config) {
 					content: {
 						'application/json': {
 							schema: {
-								$ref: `#/components/schemas/${name}_math`
+								type: 'array',
+								items: {
+									type: 'object',
+									properties: mathDefinition.properties
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Now onwards, for `/{id}/math` swagger UI will display request payload in an array format